### PR TITLE
Revert GUI workflow execution using the CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ Alternativ:
 ## GenSim CLI
 Statt der GUI kann auch die interne CLI benutzt werden um Simulationen durchzuführen. In diesem Fall muss die OSW-Datei auf anderem Weg erstellt werden. Die CLI basiert auf Ruby, daher bietet es sich an die Ruby-Installation, die auch für die GUI verwendet wird, zu benutzen. Im Folgenden wird davon ausgegangen, dass der Befehl `ruby` auf die korrekt Installation verweist.
 
+1. (Einmalig) Notwendige Gems installieren: `gem install thor`
 1. In das Hauptverzeichnis wechseln: `cd /path/to/GenSim`
     1. Im Folgenden wird davon ausgegangen, dass dieser Pfad für `.` steht. Obwohl manche Commands relative Pfade mit `.` verarbeiten können, kann dieses Verhalten nicht garantiert werden. Wenn ein Command nicht funktioniert, versuche vollständige Pfade zu verwenden statt der `.` Abkürzung.
 1. Eine leere OSM-Datei erzeugen: `ruby ./Measures/gensim_cli.rb create_empty_osm --output_folder=./Output Model.osm`

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Eine detailierte Dokumentation der Benutzung von GenSim wird auf der [offizielle
 1. OpenStudio in Version 2.7.0 installieren. Ältere Versionen sind auf der [OpenStudio GitHub Seite](https://github.com/NREL/OpenStudio/releases) zu finden.
     * Dabei sollte OpenStudio standardmäßig in den Ordner `C:\openstudio-2.7.0` installiert werden.
     * Auf der Seite "Komponenten auswählen" sollten alle Komponenten zur Installation ausgewählt sein.
-1. Das Skript `post-install.bat` ausführen um notwendige Ruby-Gem zu installieren. Es wird empfohlen dies über eine Kommandozeile durchzuführen um Fehlermeldungen sichtbar zu machen.
-    * Wenn während der Ausführung des Skriptes die Meldung `Do you want to add this insecure source?` erscheint, diese mit `y` und Eingabe bestätigen. Dies ist nur notwendig, da die Ruby-Installation von OpenStudio das normale Gem-Repository `https://rubygems.org` nicht über HTTPS verwenden kann und HTTP verwenden muss. Das Skript stellt im Anschluss die Verbindung wieder auf HTTPS um.
-    * Wenn OpenStudio nicht in den Standard-Ordner installiert wurde, muss das Skript vorher in einem Texteditor auf den verwendeten Ordner angepasst werden.
 
 ## Benutzung
 Wird bald ergänzt.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Generische Gebäudesimulation auf Basis von EnergyPlus™.
 
 GenSim erzeugt anhand einfacher Eingabeparameter ein vollständiges EnergyPlus™-Gebäudemodell, simuliert dieses und gibt anschließend Ergebnisse in Form von Lastprofilen und Jahreswerten zurück.
 
-**Die Benutzeroberfläche (GUI) für GenSim ist derzeit noch nicht im Repository enthalten. Diese wird derzeit noch für die Veröffentlichung vorbereitet und integriert sobald dies abgeschlossen ist.**
-
 # Benutzung
 Eine detailierte Dokumentation der Benutzung von GenSim wird auf der [offiziellen Dokumentation](https://quasi-software.readthedocs.io/en/latest/) des übergeordneten Projekts QuaSi zur Verfügung gestellt werden. Im Folgenden gibt es eine schnelle Einführung in die Installation und Benutzung.
 

--- a/VBAProjectFiles/IOFunctions.bas
+++ b/VBAProjectFiles/IOFunctions.bas
@@ -1,5 +1,7 @@
 Attribute VB_Name = "IOFunctions"
 
+Dim constList(0 To 29) As String
+
 Const METER_HEATING = "DistrictHeating:Facility"
 Const METER_COOLING = "DistrictCooling:Facility"
 
@@ -44,6 +46,66 @@ Const ZONE_HEATING_SEPOINT_NOT_MET_OCC = "Zone Heating Setpoint Not Met While Oc
 Const ZONE_COOLING_SEPOINT_NOT_MET = "Zone Cooling Setpoint Not Met Time"
 Const ZONE_COOLING_SEPOINT_NOT_MET_OCC = "Zone Cooling Setpoint Not Met While Occupied Time"
 
+
+Sub AssembleConstList()
+    Dim i As Integer
+    i = -1
+    constList(Inc(i)) = METER_HEATING
+    constList(Inc(i)) = METER_COOLING
+    
+    constList(Inc(i)) = METER_ELECTRICITY_LIGHTS
+    constList(Inc(i)) = METER_ELECTRICITY_PLUGS
+    
+    constList(Inc(i)) = METER_ELECTRICITY_FANS
+    constList(Inc(i)) = METER_ELECTRICITY_PUMPS
+    
+    constList(Inc(i)) = METER_ZONE_PLUGS
+    constList(Inc(i)) = METER_ZONE_LIGHTS
+    constList(Inc(i)) = METER_ZONE_PEOPLE
+    
+    constList(Inc(i)) = METER_WINDOW_SURFACE_HEAT_GAIN
+    constList(Inc(i)) = METER_WINDOW_SURFACE_HEAT_LOSS
+    
+    constList(Inc(i)) = METER_INTERNAL_LOADS
+    
+    constList(Inc(i)) = METER_SURFACE_FACE_CONDUCTION_TOTAL
+    
+    constList(Inc(i)) = METER_INFILTRATION_HEAT_LOSS
+    constList(Inc(i)) = METER_INFILTRATION_HEAT_GAIN
+    constList(Inc(i)) = METER_VENTILATION_HEAT_LOSS
+    constList(Inc(i)) = METER_VENTILATION_HEAT_GAIN
+    
+    constList(Inc(i)) = Zone_Mechanical_Ventilation_Cooling_Load_Increase_Energy
+    constList(Inc(i)) = Zone_Mechanical_Ventilation_No_Load_Heat_Removal_Energy
+    
+    constList(Inc(i)) = METER_ELECTRICITY_PV
+    constList(Inc(i)) = METER_ELECTRICITY_PRODUCED
+    
+    constList(Inc(i)) = FACILITY_HEATING_SEPOINT_NOT_MET
+    constList(Inc(i)) = FACILITY_HEATING_SEPOINT_NOT_MET_OCC
+    constList(Inc(i)) = FACILITY_COOLING_SEPOINT_NOT_MET
+    constList(Inc(i)) = FACILITY_COOLING_SEPOINT_NOT_MET_OCC
+    
+    Dim cb_detailed_zone_Results As CheckBox
+    Set cb_detailed_zone_Results = Sheets("Parameter").CheckBoxes("checkbox_ZoneDetails")
+    detailed_zone_Results = cb_detailed_zone_Results.Value = 1
+    
+    If detailed_zone_Results Then
+        constList(Inc(i)) = ZONE_MEAN_AIR_TEMPERATURE
+        constList(Inc(i)) = ZONE_HEATING_SEPOINT_NOT_MET
+        constList(Inc(i)) = ZONE_HEATING_SEPOINT_NOT_MET_OCC
+        constList(Inc(i)) = ZONE_COOLING_SEPOINT_NOT_MET
+        constList(Inc(i)) = ZONE_COOLING_SEPOINT_NOT_MET_OCC
+    Else
+        constList(Inc(i)) = ""
+        constList(Inc(i)) = ""
+        constList(Inc(i)) = ""
+        constList(Inc(i)) = ""
+        constList(Inc(i)) = ""
+    End If
+    
+End Sub
+
 Function Inc(ByRef data As Integer)
     data = data + 1
     Inc = data
@@ -74,6 +136,36 @@ Function CheckErrFile(filePath As String) As String
     Loop
     txtStream.Close
     CheckErrFile = ""
+End Function
+
+Function ConvertESOFile(filePath As String) As Boolean
+    AssembleConstList
+    
+    Dim rviFile As String
+    rviFile = GetOutputFolder() + "\Rvi.rvi"
+    
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim oFile As Object
+    Set oFile = fso.CreateTextFile(rviFile)
+    oFile.WriteLine filePath
+    oFile.WriteLine Replace(filePath, ".eso", ".csv")
+    For Each item In constList
+        oFile.WriteLine item
+    Next item
+    oFile.WriteLine "0"
+    oFile.Close
+    Set fso = Nothing
+    Set oFile = Nothing
+    
+    retval = ExecCmd(Application.ActiveWorkbook.path + "\ReadVarsEso\ReadVarsEso.exe " + Chr(34) + rviFile + Chr(34) + " unlimited ")
+    If retval > 0 Then
+        MsgBox "Fehler waehrend der Generation der CSV Datei, Fehler Code: " & retval
+        Range("SimStatus") = "Simulation nicht erfolgreich"
+        ConvertESOFile = False
+    Else
+        ConvertESOFile = True
+    End If
 End Function
 
 Function ImportCSVFileNEW(filePath As String) As Boolean

--- a/VBAProjectFiles/RunOpenStudioCLI.bas
+++ b/VBAProjectFiles/RunOpenStudioCLI.bas
@@ -44,18 +44,12 @@ Sub RunOpenStudioCLI()
     DoEvents
     If Range("SimStatus") = "Erfolgreich" Then
         Range("Status").Offset(3, 0) = "CSV Datei generieren"
+        If IOFunctions.ConvertESOFile(GetOutputFolder() & "\run\eplusout.eso") Then
+            Range("Status").Offset(3, 1) = "beendet (" & WorksheetFunction.Round((Time - Startzeit_indv) * 86400, 1) & " s)"
+            Startzeit_indv = Time
 
-        Argument = GetRubyExePath() & " " & Chr(34) & GetMeasuresFolder & "/gensim_cli.rb" & Chr(34) _
-            & " convert_eso_to_csv --output_folder=" & Chr(34) & GetOutputFolder() & "/run" & Chr(34) _
-            & " --converter_exe=" & Chr(34) & Application.ActiveWorkbook.path _
-            & "/ReadVarsEso/ReadVarsESO.exe" & Chr(34) & " eplusout.eso"
-        retval = ExecCmd(Argument)
+            DoEvents
 
-        Range("Status").Offset(3, 1) = "beendet (" & WorksheetFunction.Round((Time - Startzeit_indv) * 86400, 1) & " s)"
-        Startzeit_indv = Time
-        DoEvents
-
-        If retval = 0 Then
             Range("Status").Offset(4, 0) = "CSV Datei importieren"
             IOFunctions.ImportCSVFileNEW GetOutputFolder() & "\run\eplusout.csv"
             Range("Status").Offset(4, 1) = "beendet (" & WorksheetFunction.Round((Time - Startzeit_indv) * 86400, 1) & " s)"

--- a/VBAProjectFiles/RunOpenStudioCLI.bas
+++ b/VBAProjectFiles/RunOpenStudioCLI.bas
@@ -3,17 +3,11 @@ Sub RunOpenStudioCLI()
     Dim Argument As String
     Dim processMessage As String
 
+    CreateEmptyOSMFile GetOutputFolder() & "\" + Range("FileName") + ".osm"
+
+    Argument = Chr(34) & GetOpenStudioBinPath() & "\OpenStudio.exe" & Chr(34) & " --verbose run --workflow " & Chr(34) & GetOutputFolder() & "\" + Range("FileName") + ".osw" & Chr(34)
+
     Sheets("Hauptseite").Select
-
-    Argument = GetRubyExePath() & " " & Chr(34) & GetMeasuresFolder & "/gensim_cli.rb" & Chr(34) _
-        & " create_empty_osm --output_folder=" & Chr(34) & GetOutputFolder() & Chr(34) _
-        & " " & Range("FileName") + ".osm"
-    retval = ExecCmd(Argument)
-
-    Argument = GetRubyExePath() & " " & Chr(34) & GetMeasuresFolder & "/gensim_cli.rb" & Chr(34) _
-        & " run_workflow --output_folder=" & Chr(34) & GetOutputFolder() & Chr(34) _
-        & " --os_bin_path=" & Chr(34) & GetOpenStudioBinPath() & "/openstudio.exe" & Chr(34) _
-        & " " + Range("FileName") + ".osw"
     retval = ExecCmd(Argument)
 
     Range("Status").Offset(1, 1) = "beendet (" & WorksheetFunction.Round((Time - Startzeit_indv) * 86400, 1) & " s)"
@@ -81,4 +75,19 @@ Sub RunOpenStudioCLI()
             DoEvents
         End If
     End If
+End Sub
+
+Sub CreateEmptyOSMFile(sOSMFilePath As String)
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim oFile As Object
+    Set oFile = fso.CreateTextFile(sOSMFilePath)
+    oFile.WriteLine "OS:Version,"
+    oFile.WriteLine "  {0f20289d-c9f3-4775-8548-e6b6a77e899a}, !- Handle"
+    oFile.WriteLine "  2.5.0;                                  !- Version Identifier"
+    oFile.WriteLine ""
+    ' should we include anything Else here To make it run smoother?
+    oFile.Close
+    Set fso = Nothing
+    Set oFile = Nothing
 End Sub

--- a/VBAProjectFiles/ShellUtilities.bas
+++ b/VBAProjectFiles/ShellUtilities.bas
@@ -13,7 +13,9 @@ Attribute VB_Name = "ShellUtilities"
 ' Copyright 2015 User 'Brian Burns'
 ' Released under Creative Commons Attribution-ShareAlike 3.0 Unported
 ' Full text of license available here: https://creativecommons.org/licenses/by-sa/3.0/legalcode
-Option Explicit
+
+' The following line commented out for reasons explained in function ExecCmd
+' Option Explicit
 
 Private Type STARTUPINFO
     cb As Long
@@ -66,7 +68,10 @@ Private Const INFINITE = -1&
 Public Function ExecCmd(cmdline$)
     Dim proc As PROCESS_INFORMATION
     Dim start As STARTUPINFO
-    Dim ret As LongPtr
+    ' Variable `ret` is undeclared to fix a problem with differing return value types in
+    ' different version of Excel. Without using `Option Explicit` we can assign a value
+    ' to `ret` without having it declared first
+    ' Dim ret As LongPtr
     Dim retval As Long
 
     ' Initialize the STARTUPINFO structure:

--- a/post-install.bat
+++ b/post-install.bat
@@ -1,5 +1,0 @@
-call C:\openstudio-2.7.0\pat\ruby\bin\gem.bat sources -r https://rubygems.org
-call C:\openstudio-2.7.0\pat\ruby\bin\gem.bat sources -a http://rubygems.org
-call C:\openstudio-2.7.0\pat\ruby\bin\gem.bat install thor
-call C:\openstudio-2.7.0\pat\ruby\bin\gem.bat sources -r http://rubygems.org
-call C:\openstudio-2.7.0\pat\ruby\bin\gem.bat sources -a https://rubygems.org


### PR DESCRIPTION
* Revert GUI workflow execution using the CLI
    * While it is preferred for both the GUI and other tools to use the CLI to run workflows, this adds additional installation steps for users. It was deemed better to keep the installation simple and trade code duplication
 * Remove note in README on how the GUI is not yet released
 * Fix a problem with executing commands in different versions of Excel